### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI - Build Validation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mistalan/pixels-refactory/security/code-scanning/1](https://github.com/mistalan/pixels-refactory/security/code-scanning/1)

To fix the problem, introduce a `permissions` block with the least privileges required. Here, the workflow appears to only need read access to repository contents (for checkout). Therefore, we can safely add `permissions: contents: read` at the workflow root, directly after the `name` field and before the `on:` block. This ensures that all jobs default to these minimal permissions unless one is overridden locally. No new imports, methods, or external definitions are needed, as this is a YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
